### PR TITLE
Invoice (dummy) and PayMenu

### DIFF
--- a/src/Presenter.js
+++ b/src/Presenter.js
@@ -12,14 +12,15 @@
 //     - then send the view data back to the view
 
 import React, { Component } from 'react'
-import constants from "./constants";
+import Home from "./views/Home"
 import Login from './views/Login'
+import {CardList} from "./views/CardList"
+import Invoice from "./views/Invoice";
 import Menu from "./components/Menu"
 import Loading from "./views/Loading";
-import Home from "./views/Home"
-import {getEntityIdByUsername} from './models'
-import {CardList} from "./views/CardList"
+import constants from "./constants";
 import './Presenter.css'
+import {getEntityIdByUsername} from './models'
 
 const VIEW = constants.VIEW;
 const PERSONA = constants.PERSONA;
@@ -52,6 +53,9 @@ class Presenter extends Component {
       case VIEW.cardList:
          this.transitionToCardList();
          break;
+      case VIEW.invoice:
+        this.transitionToInvoice();
+        break;
       default:
         this.transitionToHome();
         break;
@@ -75,8 +79,9 @@ class Presenter extends Component {
 
   // TODO: Remove when Buyer Invoice page created.
   // This is currently testing that a function would be properly called.
-  TEMPtransitionToInvoice(ID) {
-    console.log("TEST: Would Transition To Invoice - " + ID);
+  transitionToInvoice() {
+    // console.log("TEST: Would Transition To Invoice - " + ID);
+    this.setState({currentView: VIEW.invoice,});
   }
 
   // transitionToSellerList(){}       // TODO: Later
@@ -129,6 +134,10 @@ class Presenter extends Component {
     global.viewStatus = status;
   }
 
+  setInvoiceID(ID){
+    global.viewInvoiceID = ID;
+  }
+
   // Views to pass ----------------------------------//
   viewSwitch(view){
     switch(view){
@@ -138,6 +147,8 @@ class Presenter extends Component {
         return <Home/>;
       case VIEW.cardList:
         return <CardList/>;
+      case VIEW.invoice:
+        return <Invoice/>;
       default:
         return <Home/>;
     }

--- a/src/components/PayMenu.js
+++ b/src/components/PayMenu.js
@@ -1,0 +1,39 @@
+/* Pay Menu is the payment confirmation menu for the Invoice View */
+
+import React, {Component} from "react";
+import constants from "../constants";
+import {Card} from "./Card";
+
+const VIEW = constants.VIEW;
+
+class PayMenu extends Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+    };
+    this.transitionTo = this.transitionTo.bind(this);
+    this.togglePayMenuOpen = this.togglePayMenuOpen.bind(this);
+  }
+
+  transitionTo(view){
+    this.togglePayMenuOpen();
+    global.presenter.transitionTo(view);
+  }
+
+  togglePayMenuOpen(){
+    this.props.invoice.togglePayMenuOpen()
+  }
+
+  render() {
+    return (
+      <div
+        onClick={() => this.togglePayMenuOpen()}
+      >
+        Pay Menu is Open!!
+      </div>
+    );
+  }
+}
+
+export default PayMenu;

--- a/src/constants.js
+++ b/src/constants.js
@@ -38,5 +38,6 @@ export default {
         home: 'home',
         orderList: 'orderList',
         cardList: 'cardList',
+        invoice: 'invoice',
     }
 }

--- a/src/global.js
+++ b/src/global.js
@@ -24,6 +24,8 @@ const global = {
   viewStatus: "orig",
   currentView: VIEW.login,
 
+  viewInvoiceID: '',
+
   /* Style -------------------------------*/
   // menuColor: 'transparent', // TODO: replace with CSS?
 };

--- a/src/views/CardList.js
+++ b/src/views/CardList.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import {getOrdersOverview} from '../data/CardData'
 import {Card} from '../components/Card'
 import "./CardList.css"
+import constants from "../constants";
 
 /**
  * A component with a high-level view of every order of viewStatus 'viewStatus' where the entity 'entityId'
@@ -12,6 +13,9 @@ import "./CardList.css"
  * @props status - The status of orders.
  * @props cardClickHandler - The function that is called to change views upon a card click
  */
+
+const VIEW = constants.VIEW;
+
 export class CardList extends Component {
 
     constructor(props) {
@@ -20,6 +24,7 @@ export class CardList extends Component {
             'ordersData': []
         };
         this.setOrdersData = this.setOrdersData.bind(this);
+        this.transitionToInvoiceID = this.transitionToInvoiceID.bind(this);
     }
 
     componentDidMount() {
@@ -28,6 +33,11 @@ export class CardList extends Component {
 
     setOrdersData(ordersData) {
         this.setState({'ordersData': ordersData});
+    }
+
+    transitionToInvoiceID(ID){
+        global.presenter.setInvoiceID(ID);
+        global.presenter.transitionTo(VIEW.invoice);
     }
 
     createCards() {
@@ -40,7 +50,7 @@ export class CardList extends Component {
                 id={id}
                 key={key}
                 orderData={this.state.ordersData[key]}
-                onClick={() => global.presenter.TEMPtransitionToInvoice(id)}/>;
+                onClick={() => this.transitionToInvoiceID(id)}/>;
             cards.push(card);
         }
         return cards;

--- a/src/views/Invoice.css
+++ b/src/views/Invoice.css
@@ -1,0 +1,22 @@
+/* Invoice CSS */
+
+#invoice_container {
+    position: fixed;
+    width: 100vw;
+    height: 100vh;
+    z-index: 9999;
+    display: flex;
+    flex-direction:column;
+    align-items: center;
+    justify-content: center;
+}
+
+.invoice_block {
+    display: flex;
+    flex-direction: column;
+    /*width: 300px;*/
+    font-family: 'Cabin', sans-serif;
+    font-weight: 700;
+    color: var(--WHITE);
+    font-size: 30px;
+}

--- a/src/views/Invoice.js
+++ b/src/views/Invoice.js
@@ -1,0 +1,74 @@
+/*
+* This component will display the contents of the invoice.
+* If this is a Buying Invoice, it will have an option to pay,
+* which will reveal a pay menu (transitioning to RTP)
+*/
+
+import React, { Component } from 'react';
+import constants from "../constants";
+import "./Invoice.css"
+import PayMenu from "../components/PayMenu.js"
+
+const VIEW = constants.VIEW;
+
+class Invoice extends Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      payMenuOpen: false,
+    };
+    this.togglePayMenuOpen = this.togglePayMenuOpen.bind(this);
+  }
+
+  togglePayMenuOpen(){
+    this.setState(prevState => ({payMenuOpen: !prevState.payMenuOpen}));
+  }
+
+  // TODO: Getting Invoice Logic
+
+  render() {
+    const { payMenuOpen } = this.state;
+
+    return (
+      <div id={"invoice_container"}>
+
+        {/* Invoice Contents goes Here */}
+        <div
+          className={"invoice_block"}
+        >
+          INVOICE #{global.viewInvoiceID}
+        </div>
+        <div className={"invoice_block"}>
+          SOME INFORMATION
+        </div>
+        <div className={"invoice_block"}>
+          SOME INFORMATION
+        </div>
+        <div className={"invoice_block"}>
+          ~~~~~~
+        </div>
+        {/* Invoice Contents goes Here */}
+
+
+        {/* PayMenu interaction IF status is UNPAID */}
+        <div
+          className={"invoice_block"}
+          onClick={() => this.togglePayMenuOpen()}
+        >
+          ~ Pay Menu Button ~
+        </div>
+        {payMenuOpen &&
+          <PayMenu
+            payMenuOpen={this.state.payMenuOpen}
+            invoice={this}
+          />
+        }
+      </div>
+
+    );
+  }
+
+}
+
+export default Invoice;


### PR DESCRIPTION
Added a dummy `Invoice` page with interaction to reveal the `PayMenu`.

Currently `CardList` will, upon clicking a `Card`, use presenter to` setInvoiceID` to the `global` variable, and transition to the `Invoice` view. 

There is a dummy button to toggle the `PayMenu` visibility.

`Invoice` will need logic to generate the invoice contents from the `ID`.
